### PR TITLE
Change README instructions to avoid inline password being saved in your history.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,16 +95,18 @@ If you feel uncomfortable giving your GitHub username and password to the
 plugin, you can generate a GitHub API access token yourself. Just open up
 a Terminal window/shell (Windows users, you're on your own here), and run:
 
-    curl -u "username:password" -d '{"scopes":["gist"]}' https://api.github.com/authorizations
+    curl -u username -d '{"scopes":["gist"]}' https://api.github.com/authorizations
 
-where `username` and `password` are your GitHub credentials. You'll get back
-a JSON response that includes a 40-digit "token" value (e.g. `6423ba8429a152ff4a7279d1e8f4674029d3ef87`).
+where `username` is your GitHub username. You'll be prompt for your password first. Then you'll get back
+a response that includes a 40-digit "token" value (e.g. `6423ba8429a152ff4a7279d1e8f4674029d3ef87`).
 Go to Sublime Text 2 -> Preferences -> Package Settings -> GitHub -> Settings - User,
 and insert the token there. It should look like:
 
     {
         "github_token": "6423ba8429a152ff4a7279d1e8f4674029d3ef87"
     }
+
+Restart Sublime.
 
 That's it!
 


### PR DESCRIPTION
Everything went fine except I had a concern with typing my password into
the curl command directly. I didn't want my github password to be expose
in my history. `curl` will prompt you for your password unless given on
the command line.

The plugin was not taking my token until I restarted Sublime even with the file `GitHub.sublime-settings` set correctly.
