### PR TITLE
Add copy url to clipboard method

### DIFF
--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,6 +1,6 @@
 [
 { "keys": ["super+g", "super+n"], "command": "public_gist_from_selection" },
 { "keys": ["super+g", "super+p","super+n"], "command": "private_gist_from_selection" },
-{ "keys": ["super+g", "super+g"], "command": "open_gist_in_editor" },
+{ "keys": ["super+g", "super+o"], "command": "open_gist_in_editor" },
 { "keys": ["super+g", "super+c"], "command": "open_gist_url" }
 ]

--- a/Github.sublime-commands
+++ b/Github.sublime-commands
@@ -5,6 +5,7 @@
     { "caption": "GitHub: Copy Starred Gist to Clipboard", "command": "open_starred_gist" },
     { "caption": "GitHub: Open Gist in Editor", "command": "open_gist_in_editor" },
     { "caption": "GitHub: Open Starred Gist in Editor", "command": "open_starred_gist_in_editor" },
+    { "caption": "GitHub: Copy Gist URL to Clipboard", "command": "open_gist_url" },
     { "caption": "GitHub: Open Gist in Browser", "command": "open_gist_in_browser" },
     { "caption": "GitHub: Open Starred Gist in Browser", "command": "open_starred_gist_in_browser" },
     { "caption": "GitHub: Update Gist", "command": "update_gist" }

--- a/sublime_github.py
+++ b/sublime_github.py
@@ -78,6 +78,7 @@ class OpenGistCommand(BaseGitHubCommand):
     starred = False
     open_in_editor = False
     syntax_file_map = None
+    copy_gist_id = False
 
     def run(self, edit):
         super(OpenGistCommand, self).run(edit)
@@ -139,6 +140,8 @@ class OpenGistCommand(BaseGitHubCommand):
             new_view.end_edit(edit)
             new_view.set_name(filename)
             new_view.settings().set('gist', gist)
+        elif self.copy_gist_id:
+            sublime.set_clipboard(gist["html_url"])
         else:
             sublime.set_clipboard(content)
             sublime.status_message(self.MSG_SUCCESS % filename)
@@ -178,6 +181,11 @@ class OpenGistInEditorCommand(OpenGistCommand):
     """
     open_in_editor = True
 
+class OpenGistUrlCommand(OpenGistCommand):
+    """
+    Open a gist url in a new editor.
+    """
+    copy_gist_id = True
 
 class OpenStarredGistInEditorCommand(OpenGistCommand):
     """


### PR DESCRIPTION
I added a method for copying a gist url to the clipboard. I apologize if this is ugly, I have zero experience with python. I also added a few keybindings that I use as well. Thanks a bunch for the plugin :)
