### PR TITLE
Add proxy support

### DIFF
--- a/github.py
+++ b/github.py
@@ -28,10 +28,12 @@ class GitHubApi(object):
         "Raised if we get a ConnectionError"
         pass
 
-    def __init__(self, base_uri="https://api.github.com", token=None, debug=False):
+    def __init__(self, base_uri="https://api.github.com", token=None, debug=False, proxies=None):
         self.base_uri = base_uri
         self.token = token
         self.debug = debug
+        self.proxies = proxies
+
         if debug:
             logger.setLevel(logging.DEBUG)
 
@@ -51,6 +53,7 @@ class GitHubApi(object):
         }
         resp = self.rsession.post(self.base_uri + "/authorizations",
                                   auth=(username, password),
+                                  proxies=self.proxies,
                                   data=json.dumps(auth_data))
         if resp.status_code == requests.codes.CREATED:
             data = json.loads(resp.text)
@@ -90,6 +93,7 @@ class GitHubApi(object):
                                      headers=headers,
                                      params=params,
                                      data=data,
+                                     proxies=self.proxies,
                                      allow_redirects=True)
         except ConnectionError, e:
             raise self.ConnectionException("Connection error, "

--- a/sublime_github.py
+++ b/sublime_github.py
@@ -58,7 +58,9 @@ class BaseGitHubCommand(sublime_plugin.TextCommand):
                 sublime.save_settings("GitHub.sublime-settings")
         self.base_uri = self.accounts[self.active_account]["base_uri"]
         self.debug = self.settings.get('debug')
-        self.gistapi = GitHubApi(self.base_uri, self.github_token, debug=self.debug)
+
+        self.proxies = {'https': self.accounts[self.active_account].get("https_proxy", None)}
+        self.gistapi = GitHubApi(self.base_uri, self.github_token, debug=self.debug, proxies=self.proxies)
 
     def get_token(self):
         sublime.error_message(self.ERR_NO_USER_TOKEN)


### PR DESCRIPTION
The first patch simply adds a visible message when a ConnectionError occurs.
This is quite useful, because previously it failed silently and I had to skim through the console logs in order to understand what was wrong.

The second patch adds proxy support, but note that https support is buggy in requests.
I've been tracking the related issues [1, 2], but should work properly once they're fixed.
