### PR TITLE
Allow RemoteUrlCommand based commands to work with non .com private repos

### DIFF
--- a/sublime_github.py
+++ b/sublime_github.py
@@ -383,11 +383,9 @@ if git:
         def done_remote(self, result):
             remote_loc = result.split()[0]
             repo_url = re.sub('^git(@|://)', 'http://', remote_loc)
-
-            # Replace the "tld:" with "tld/". See http://rubular.com/r/FK3w7CVnx5
-            tld_pattern = r'\.(com|net|org|co\..{2}):'
-            repo_url = re.sub(tld_pattern, r'.\1/', repo_url)
-
+            # Replace the "tld:" with "tld/"
+            # https://github.com/bgreenlee/sublime-github/pull/49#commitcomment-3688312
+            repo_url = re.sub(r'^(https?://[^/:]+):', r'\1/', repo_url)
             repo_url = re.sub('\.git$', '', repo_url)
             self.repo_url = repo_url
             self.run_command("git rev-parse --abbrev-ref HEAD".split(), self.done_rev_parse)


### PR DESCRIPTION
The first commit just replaces `git remote -v` and the ensuing loops/regex by using `git ls-remote`.

The next two commits allows private repos with .net/.org etc. TLDs to work with this plugin.
- replace the `:` following the TLD (`com|org|net|co.??`) with a `/`
- default to `http` for repo URL - not all GH enterprise hosted sites support `https`. When it does GH will automatically rewrite to `https` anyway.
