### PR TITLE
Use the API so that requests are authenticated

### DIFF
--- a/github.py
+++ b/github.py
@@ -152,6 +152,10 @@ class GitHubApi(object):
                                     "public": public,
                                     "files": {filename: {"content": content}}})
 
+    def get_gist(self, gist):
+        data = self.get("/gists/" + gist["id"])
+        return list(data["files"].values())[0]["content"]
+
     def update_gist(self, gist, content):
         filename = list(gist["files"].keys())[0]
         return self.patch("/gists/" + gist["id"],

--- a/sublime_github.py
+++ b/sublime_github.py
@@ -180,7 +180,7 @@ class OpenGistCommand(BaseGitHubCommand):
         gist = self.gists[idx]
         filename = list(gist["files"].keys())[0]
         filedata = gist["files"][filename]
-        content = self.gistapi.get(filedata["raw_url"])
+        content = self.gistapi.get_gist(gist)
         if self.open_in_editor:
             new_view = self.view.window().new_file()
             if expat:  # not present in Linux


### PR DESCRIPTION
Requests to get a gist from GHE were failing because they were just URL requests. This changes the behavior to use the API to retrieve the content of the gist.
