### PR TITLE
Updated token creation in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Available commands can be seen in <https://github.com/bgreenlee/sublime-github/b
 
 If you feel uncomfortable giving your GitHub username and password to the plugin, you can generate a GitHub API access token yourself. Just open up a Terminal window/shell (on OS X, Linux or Cygwin), and run:
 
-    curl -u username -d '{"scopes":["gist"]}' https://api.github.com/authorizations
+    curl -u username -d '{"scopes":["gist"], "note": "sublime-github"}' https://api.github.com/authorizations
 
 where `username` is your GitHub username. You'll be prompt for your password first. Then you'll get back a response that includes a 40-digit "token" value (e.g. `6423ba8429a152ff4a7279d1e8f4674029d3ef87`). Go to Sublime Text 2 -> Preferences -> Package Settings -> GitHub -> Settings - User, and insert the token there. It should look like:
 


### PR DESCRIPTION
Token creation details was missing the "note": field which was causing the token creation to fail.  Updated instructions to correct (tested and verified)
