### PR TITLE
Clarify GitHub Blame command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The following commands are available in the Command Palette:
 
 * **GitHub: Blame**
 
-    Open the GitHub blame view of the current file in the browser
+    Open the GitHub blame view of the current file in the browser. (Note: The browser will highlight and scroll to any currently selected code.)
 
 * **GitHub: History**
 


### PR DESCRIPTION
I had no idea until I looked at the code that you could select some text and then the GitHub Blame command would highlight that line in the blame. Maybe that could be noted in the README?