### PR TITLE
Allow users to customize the opened url

### DIFF
--- a/GitHub.sublime-settings
+++ b/GitHub.sublime-settings
@@ -14,7 +14,9 @@
     //
     // "YourCo": {
     //     "base_uri": "https://github.yourco.com/api/v3",
-    //     "github_token": ""
+    //     "github_token": "",
+    //     "protocol": "http",  // default is "https"
+    //     "remote": "upsteam"  // default is "" (no remote)
     // }
 
     // The format of the each line in the list of gists.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The following commands are available in the Command Palette:
 
 * **GitHub: Open Remote URL in Browser**
 
-    Open the current file's location in the repository in the browser. If you have any lines selected, they will be highlighted in the browser.
+    Open the current file's location in the repository in the browser. If you have any lines selected, they will be highlighted in the browser.  The default protocol is 'https'.  The default remote used is '' (no remote).  If you want to change either of those set them in your GitHub.sublime-settings file for your specific account.
 
 * **GitHub: Copy Remote URL to Clipboard**
 

--- a/sublime_github.py
+++ b/sublime_github.py
@@ -420,11 +420,22 @@ if git:
 
         def run(self, edit):
             self.settings = sublime.load_settings("GitHub.sublime-settings")
-            self.run_command("git ls-remote --get-url".split(), self.done_remote)
+            self.active_account = self.settings.get("active_account")
+            self.accounts = self.settings.get("accounts")
+
+            if not self.active_account:
+                self.active_account = list(self.accounts.keys())[0]
+
+            self.protocol = self.accounts[self.active_account].get("protocol", "https")
+            remote = self.accounts[self.active_account].get("remote", "")
+
+            command = "git ls-remote --get-url " + remote
+
+            self.run_command(command.split(), self.done_remote)
 
         def done_remote(self, result):
             remote_loc = result.split()[0]
-            repo_url = re.sub('^git(@|://)', 'https://', remote_loc)
+            repo_url = re.sub('^git(@|://)', self.protocol + '://', remote_loc)
             # Replace the "tld:" with "tld/"
             # https://github.com/bgreenlee/sublime-github/pull/49#commitcomment-3688312
             repo_url = re.sub(r'^(https?://[^/:]+):', r'\1/', repo_url)


### PR DESCRIPTION
While the hostname of the URL is pulled from the `git ls-remote`
command, the protocol is hardcoded to "https" and the remote used is
hardcoded to nothing (which defaults to origin).  This allows
customizing both of those if the github host (say, an Enterprise
installation) is using a different protocol and if you don't want to
show origin but a different branch.

My specific example is that my company's GitHub Enterprise installation is over "http" (with 443 turned off).  Additionally I usually want to show my coworkers the files on our main repo, not my fork of it.  So I have the settings as:

```
        "LivingSocial": {
            "base_uri": "http://code.livingsocial.net",
            "protocol": "http",
            "remote": "upstream"
        }
```

Please understand that Python isn't my native tongue so if I've messed up syntax, I apologize and am open to comments.  Additionally, I don't use too many other commands on this plugin so I don't know if I've broken anything else and I didn't see any tests.