### PR TITLE
Add master-specific versions of commands

### DIFF
--- a/Github.sublime-commands
+++ b/Github.sublime-commands
@@ -11,9 +11,15 @@
     { "caption": "GitHub: Update Gist", "command": "update_gist" },
     { "caption": "GitHub: Switch Accounts", "command": "switch_accounts" },
     { "caption": "GitHub: Copy Remote URL to Clipboard", "command": "copy_remote_url" },
+    { "caption": "GitHub: Copy Remote URL to Clipboard (master)", "command": "copy_remote_url_master" },
     { "caption": "GitHub: Open Remote URL in Browser", "command": "open_remote_url" },
+    { "caption": "GitHub: Open Remote URL in Browser (master)", "command": "open_remote_url_master" },
     { "caption": "GitHub: View", "command": "open_remote_url"},
+    { "caption": "GitHub: View (master)", "command": "open_remote_url_master"},
     { "caption": "GitHub: Blame", "command": "blame"},
+    { "caption": "GitHub: Blame (master)", "command": "blame_master"},
     { "caption": "GitHub: History", "command": "history"},
-    { "caption": "GitHub: Edit", "command": "edit"}
+    { "caption": "GitHub: History (master)", "command": "history_master"},
+    { "caption": "GitHub: Edit", "command": "edit"},
+    { "caption": "GitHub: Edit (master)", "command": "edit_master"}
 ]

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ The following commands are available in the Command Palette:
 
 **The following commands require the Git plugin, available through the Package Manager. After installing, restart Sublime Text.**
 
+**Note:** These commands use the currently checked out branch to generate GitHub URLs. Each command also has a corresponding version, such as **GitHub: Blame (master)**, that always uses the master branch, regardless of which branch is checked out locally.
+
 * **GitHub: Open Remote URL in Browser**
 
     Open the current file's location in the repository in the browser. If you have any lines selected, they will be highlighted in the browser.  The default protocol is 'https'.  The default remote used is '' (no remote).  If you want to change either of those set them in your GitHub.sublime-settings file for your specific account.
@@ -80,6 +82,10 @@ The following commands are available in the Command Palette:
 * **GitHub: History**
 
     Open the GitHub commit history view of the current file in the browser.
+
+* **GitHub: View**
+
+    Alias for *GitHub: Open Remote URL in Browser*
 
 * **GitHub: Edit**
 

--- a/sublime_github.py
+++ b/sublime_github.py
@@ -446,7 +446,10 @@ if git:
         # Get the repo's explicit toplevel path
         def done_toplevel(self, result):
             self.toplevel_path = result.strip()
-            self.run_command("git rev-parse --abbrev-ref HEAD".split(), self.done_rev_parse)
+            if self.master:
+                self.done_rev_parse("master")
+            else:
+                self.run_command("git rev-parse --abbrev-ref HEAD".split(), self.done_rev_parse)
 
         def done_rev_parse(self, result):
             # get current branch
@@ -483,6 +486,7 @@ else:
 
 class OpenRemoteUrlCommand(RemoteUrlCommand):
     allows_line_highlights = True
+    master = False
 
     def run(self, edit):
         super(OpenRemoteUrlCommand, self).run(edit)
@@ -491,8 +495,13 @@ class OpenRemoteUrlCommand(RemoteUrlCommand):
         webbrowser.open(self.url)
 
 
+class OpenRemoteUrlMasterCommand(OpenRemoteUrlCommand):
+    master = True
+
+
 class CopyRemoteUrlCommand(RemoteUrlCommand):
     allows_line_highlights = True
+    master = False
 
     def run(self, edit):
         super(CopyRemoteUrlCommand, self).run(edit)
@@ -502,15 +511,34 @@ class CopyRemoteUrlCommand(RemoteUrlCommand):
         sublime.status_message("Remote URL copied to clipboard")
 
 
+class CopyRemoteUrlMasterCommand(CopyRemoteUrlCommand):
+    master = True
+
+
 class BlameCommand(OpenRemoteUrlCommand):
     url_type = 'blame'
+    master = False
+
+
+class BlameMasterCommand(BlameCommand):
+    master = True
 
 
 class HistoryCommand(OpenRemoteUrlCommand):
     url_type = 'commits'
     allows_line_highlights = False
+    master = False
+
+
+class HistoryMasterCommand(HistoryCommand):
+    master = True
 
 
 class EditCommand(OpenRemoteUrlCommand):
     url_type = 'edit'
     allows_line_highlights = False
+    master = False
+
+
+class EditMasterCommand(EditCommand):
+    master = True


### PR DESCRIPTION
Add the following commands, which always use the `master` branch,
regardless of whether a different branch is checked out locally:

* `Copy Remote URL to Clipboard (master)`
* `Open Remote URL in Browser (master)`
* `View (master)`
* `Blame (master)`
* `History (master)`
* `Edit (master)`