### PR TITLE
Simplify master = False setting (more)

### DIFF
--- a/sublime_github.py
+++ b/sublime_github.py
@@ -516,7 +516,6 @@ class CopyRemoteUrlMasterCommand(CopyRemoteUrlCommand):
 
 class BlameCommand(OpenRemoteUrlCommand):
     url_type = 'blame'
-    master = False
 
 
 class BlameMasterCommand(BlameCommand):
@@ -526,7 +525,6 @@ class BlameMasterCommand(BlameCommand):
 class HistoryCommand(OpenRemoteUrlCommand):
     url_type = 'commits'
     allows_line_highlights = False
-    master = False
 
 
 class HistoryMasterCommand(HistoryCommand):
@@ -536,7 +534,6 @@ class HistoryMasterCommand(HistoryCommand):
 class EditCommand(OpenRemoteUrlCommand):
     url_type = 'edit'
     allows_line_highlights = False
-    master = False
 
 
 class EditMasterCommand(EditCommand):


### PR DESCRIPTION
Since the default of `master = False` (that is, use the current local
branch to generate GitHub URLs) has been moved up to the parent class of
`OpenRemoteUrlCommand`, these subclasses do not need to redundantly
specify `master = False`.

This PR is a followup on the changes initially introduced in https://github.com/bgreenlee/sublime-github/pull/96 and partially cleaned up in https://github.com/bgreenlee/sublime-github/commit/669aea99dd7a35e6e3eb1ca592af64aef5828785.