### PR TITLE
Get permalinks for the local HEAD not the HEAD of the remote branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The following commands are available in the Command Palette:
 
 **The following commands require the Git plugin, available through the Package Manager. After installing, restart Sublime Text.**
 
-**Note:** These commands use the currently checked out branch to generate GitHub URLs. Each command also has a corresponding version, such as **GitHub: Blame (master)**, that always uses the master branch, regardless of which branch is checked out locally. All commands except **GitHub: Edit** have a corresponding "permalink" version too, like **GitHub: Blame (permalink)**, that uses the most recent commit on the current branch ([more info](https://help.github.com/en/articles/getting-permanent-links-to-files)).
+**Note:** These commands use the currently checked-out branch to generate GitHub URLs. Each command also has a corresponding version, such as **GitHub: Blame (master)**, that always uses the master branch, regardless of which branch is checked-out locally. All commands except **GitHub: Edit** have a corresponding "permalink" version too, like **GitHub: Blame (permalink)**, that references the currently checked-out commit ([more info](https://help.github.com/en/articles/getting-permanent-links-to-files)).
 
 * **GitHub: Open Remote URL in Browser**
 


### PR DESCRIPTION
On GitHub, permalinks reference the HEAD of the remote branch since that’s
what you’re looking at when you request the permalink
(https://help.github.com/en/articles/getting-permanent-links-to-files). In
Sublime, it makes more sense for permalinks to reference your local HEAD
since _that’s_ what you’re looking at when you run a permalink command.

Referencing the local HEAD lets the user run permalink commands with a
commit checked out rather than a branch; or having checked out a branch that
they've just created, if the user has neither added commits to that branch nor
pushed the branch to the remote.

If the user _has_ added commits to such a branch without pushing them to the
remote, then the link will 404 on GitHub. Then again, previously, if the user
had pushed the branch to the remote—just not the most recent commits on
the branch—then we would have created an out-of-date permalink, and this would arguably have been a worse failure because it would be silent.

At some future point, it might be nice to detect, locally, if a permalink was
going to 404, and show an error message before the user went to GitHub.

Referencing the local HEAD also fixes a bug in the previous implementation
where we’d only successfully fetch the remote HEAD if the name of the remote
branch was exactly the same as the local branch, since we executed
`git rev-parse <remote_branch>` at line 508 without prefixing
`remote_branch` with the name of the remote.

Tests:
- [x] “Open Remote URL in Browser” works if the current branch has been
  pushed to the remote
- [x] “Open Remote URL in Browser” shows an error alert if the current branch
  has not been pushed to the remote
- [x] “Open Remote URL in Browser” shows an error alert if a commit is
  checked out rather than a branch
- [x] “Open Remote URL in Browser (permalink)” works if the current branch
  has been pushed to the remote
- [x] “Open Remote URL in Browser (permalink)” works if a commit is checked
  out vs. a branch
- [x] “Open Remote URL in Browser (permalink)” works if a branch is checked
  out and the user has not pushed that branch but has also not added commits
  to that branch
- [x] “Open Remote URL in Browser (permalink)” results in a 404 on GitHub
  if the user has added commits to a branch and not pushed them to GitHub
- [x] “Open Remote URL in Browser (master)” works regardless of what’s checked out above