### PR TITLE
Enable fetching git default branch dynamically instead of settings

### DIFF
--- a/GitHub.sublime-settings
+++ b/GitHub.sublime-settings
@@ -45,5 +45,6 @@
 
     // The default branch to use when issuing Copy Remote URL to Clipboard, Open Remote URL in Browser, View, Blame,
     // History, or Edit commands
+    // Set to falsey values to fetch the current repo's default branch
     "default_branch": "main",
 }

--- a/sublime_github.py
+++ b/sublime_github.py
@@ -436,9 +436,21 @@ if git:
                 if default_branch_setting:
                     branch = default_branch_setting
                 else:
+                    # Get the path of the currently opened file
+                    file_path = self.view.window().active_view().file_name()
+
+                    # Get the list of folders in the project
+                    folders = self.view.window().folders()
+
+                    top_level_folder = None
+                    for folder in folders:
+                        if file_path.startswith(folder):
+                            top_level_folder = folder
+                            break
+
                     branch = (
                         subprocess.check_output(
-                            "git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'",
+                            "git -C %s symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'"%(top_level_folder),
                             stderr=subprocess.STDOUT,
                             shell=True,
                         )

--- a/sublime_github.py
+++ b/sublime_github.py
@@ -9,6 +9,7 @@ import logging as logger
 import plistlib
 import sublime
 import sublime_plugin
+import subprocess
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from github import GitHubApi
@@ -430,7 +431,20 @@ if git:
         def run(self, edit):
             if self.branch == "default":
                 self.settings = sublime.load_settings("GitHub.sublime-settings")
-                branch = self.settings.get("default_branch")
+                default_branch_setting = self.settings.get("default_branch")
+
+                if default_branch_setting:
+                    branch = default_branch_setting
+                else:
+                    branch = (
+                        subprocess.check_output(
+                            "git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'",
+                            stderr=subprocess.STDOUT,
+                            shell=True,
+                        )
+                        .decode("utf-8")
+                        .strip()
+                    )
             else:
                 # Get the current remote branch--useful whether we want to link directly to that
                 # branch or to the branch's HEAD.


### PR DESCRIPTION
Given the context that I have been working on multiple repos with different default branches, I've recently faced errors no on uncommitted branches.

<img width="258" alt="Screenshot 2023-11-10 at 18 40 22" src="https://github.com/bgreenlee/sublime-github/assets/5253209/17fbf11e-50d8-471f-b7dd-c2737971b3c2">

The cmd of `Github: Blame (default branch)` calling to `main` concretely instead of `master` or `development` (depending on which repo) is untrue.

By configuring `"default_branch": ""`, this PR is now dynamically allowing us to fetch the true default branch which is defined by the active git repo. Hence we can enjoy `Github: Blame (default branch)` when working in pre-push style.